### PR TITLE
feat: make calendar

### DIFF
--- a/mj-diary/src/App.vue
+++ b/mj-diary/src/App.vue
@@ -4,7 +4,7 @@
       Prev
     </router-link>
     <img src="/mood/happiness.png" class="logo" />
-    <router-link class="header-button-right" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
+    <router-link @click="this.$store.commit('submitDiary')" class="header-button-right" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
       Submit
     </router-link>
   </div>

--- a/mj-diary/src/App.vue
+++ b/mj-diary/src/App.vue
@@ -4,7 +4,7 @@
       Prev
     </router-link>
     <img src="/mood/happiness.png" class="logo" />
-    <router-link @click="this.$store.commit('submitDiary')" class="header-button-right" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
+    <router-link @click="this.$store.dispatch('submitDiary')" class="header-button-right" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
       Submit
     </router-link>
   </div>
@@ -19,7 +19,14 @@
 
 <script>
 export default {
-  name: 'app'
+  name: 'app',
+  methods: {
+    goMainPage(path) {
+      if(path == `/write/${this.$store.state.writeDate}`) {
+
+      }
+    }
+  }
 }
 </script>
 

--- a/mj-diary/src/App.vue
+++ b/mj-diary/src/App.vue
@@ -1,10 +1,10 @@
 <template>
   <div v-if="$route.path != `/`" class="header">
-    <router-link class="header-button-left" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
+    <router-link @click="this.$store.commit('setShowButton')" class="header-button-left" v-if="this.$store.state.showNavButton" to="/main">
       Prev
     </router-link>
     <img src="/mood/happiness.png" class="logo" />
-    <router-link @click="this.$store.dispatch('submitDiary')" class="header-button-right" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
+    <router-link @click="this.$store.dispatch('submitDiary')" class="header-button-right" v-if="this.$store.state.showNavButton" to="/main">
       Submit
     </router-link>
   </div>
@@ -20,13 +20,6 @@
 <script>
 export default {
   name: 'app',
-  methods: {
-    goMainPage(path) {
-      if(path == `/write/${this.$store.state.writeDate}`) {
-
-      }
-    }
-  }
 }
 </script>
 

--- a/mj-diary/src/App.vue
+++ b/mj-diary/src/App.vue
@@ -1,10 +1,10 @@
 <template>
   <div v-if="$route.path != `/`" class="header">
-    <router-link class="header-button-left" v-if="$route.path == `/write/1`" to="/main">
+    <router-link class="header-button-left" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
       Prev
     </router-link>
     <img src="/mood/happiness.png" class="logo" />
-    <router-link class="header-button-right" v-if="$route.path == `/write/1`" to="/main">
+    <router-link class="header-button-right" v-if="$route.path == `/write/${this.$store.state.writeDate}`" to="/main">
       Submit
     </router-link>
   </div>

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -44,8 +44,8 @@ export default {
 
 <style>
 .select-month {
-  margin-top: 8px;
-  margin-bottom: 16px;
+  margin-top: 0.75rem;
+  margin-bottom: 1.5rem;
   display: flex;
   flex-direction: row;
   justify-content: space-around;
@@ -95,7 +95,7 @@ export default {
 }
 .date-block {
   width: 42px;
-  height: 72px;
+  height: 50px;
   margin-bottom: 16px;
   display: flex;
   align-items: flex-start;
@@ -119,7 +119,7 @@ export default {
   justify-content: center;
   align-items: center;
   position: fixed;
-  bottom: 104px;
+  bottom: 7.5rem;
   right: 32px;
 }
 </style>

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -40,8 +40,8 @@ export default {
     this.$store.commit('loadCalendar');
   },
   methods: {
-    reloadCalendar(v) {
-      this.$store.state.today = new Date(this.$store.state.today.setMonth(this.$store.state.today.getMonth() + v, 1));
+    reloadCalendar(moveMonth) {
+      this.$store.state.today = new Date(this.$store.state.today.setMonth(this.$store.state.today.getMonth() + moveMonth, 1));
       this.$store.commit('loadCalendar');
     },
     goWrite(year, month, day) {

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -1,24 +1,24 @@
 <template>
   <div class="select-date">
     <div class="select-month">
-    <div class="last-month">{{ this.$store.state.prev }}</div>
+    <div class="last-month" @click="reloadCalendar(-1)">{{ this.$store.state.prev }}</div>
     <div class="month-block">
-      <div class="year">2024</div>
-      <div class="month">01</div>
+      <div class="year">{{ this.$store.state.year }}</div>
+      <div class="month">{{ this.$store.state.month + 1 }}</div>
     </div>
-    <div class="next-month">></div>
+    <div class="next-month" @click="reloadCalendar(1)">></div>
   </div>
   </div>
   <div class="calendar-block">
     <table class="calendar">
       <thead class="week-block">
-        <tr class="week" v-for="week, index in weeks" :key="index">
+        <tr class="week" v-for="week, index in this.$store.state.weeks" :key="index">
           <th>{{ week }}</th>
         </tr>
       </thead>
       <tbody class="date-body">
-        <tr class="date-row" v-for="index, i in dates" :key="i">
-          <td class="date-block" v-for="date, secIndex in index" :key="secIndex">
+        <tr class="date-row" v-for="index, i in this.$store.state.days" :key="i">
+          <td class="date-block" v-for="date in index" :key="date">
             <router-link class="date" to="/write/1">{{ date }}</router-link>
           </td>
         </tr>
@@ -30,15 +30,13 @@
 
 <script>
 export default {
-  data() {
-    return {
-      weeks: ['MON',	'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'],
-      dates: [[1, 2, 3, 4, 5, 6, 7],
-              [8, 9, 10, 11, 12, 13, 14],
-              [15, 16, 17, 18, 19, 20, 21],
-              [22, 23, 24, 25, 26, 27, 28],
-              [29, 30, 31, '', '', '', '']],
-      
+  mounted() {
+    this.$store.commit('loadCalendar');
+  },
+  methods: {
+    reloadCalendar(v) {
+      this.$store.state.today = new Date(this.$store.state.today.setMonth(this.$store.state.today.getMonth() + v, 1));
+      this.$store.commit('loadCalendar');
     }
   }
 }
@@ -52,6 +50,12 @@ export default {
   flex-direction: row;
   justify-content: space-around;
   align-items: center;
+}
+.last-month {
+  cursor: pointer;
+}
+.next-month {
+  cursor: pointer;
 }
 .month-block {
   display: flex;

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="select-date">
     <div class="select-month">
-    <div class="last-month" @click="reloadCalendar(-1)">{{ this.$store.state.prev }}</div>
+    <div class="last-month" @click="reloadCalendar(-1)">{{ prev }}</div>
     <div class="month-block">
       <div class="year">{{ this.$store.state.year }}</div>
       <div class="month">{{ this.$store.state.month + 1 }}</div>
@@ -30,6 +30,11 @@
 
 <script>
 export default {
+  data() {
+    return {
+      prev: "<",
+    }
+  },
   mounted() {
     this.$store.commit('loadCalendar');
   },

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -48,6 +48,7 @@ export default {
       this.$store.state.wirteMonth = String(month + 1).padStart(2, "0");
       this.$store.state.writeDay = String(day).padStart(2, "0");
       this.$store.state.writeDate = String(year) + this.$store.state.wirteMonth + this.$store.state.writeDay;
+      this.$store.commit('setShowButton');
       this.$router.push(`/write/${this.$store.state.writeDate}`)
     }
   }

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -74,9 +74,7 @@ export default {
 }
 .calendar {
   width: calc(100% - 24px);
-  padding-left: 12px;
-  padding-right: 12px;
-  padding-top: 12px;
+  padding: 12px;
   background-color: rgb(255, 255, 152);
 }
 .week-block {
@@ -102,9 +100,10 @@ export default {
 .day-block {
   width: 42px;
   height: 50px;
-  margin-bottom: 16px;
+  padding-top: 8px;
+  padding-bottom: 8px;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
 }
 .day {

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -3,8 +3,8 @@
     <div class="select-month">
     <div class="last-month" @click="reloadCalendar(-1)">{{ prev }}</div>
     <div class="month-block">
-      <div class="year">{{ this.$store.state.year }}</div>
-      <div class="month">{{ this.$store.state.month + 1 }}</div>
+      <div class="year">{{ this.$store.state.date.year }}</div>
+      <div class="month">{{ this.$store.state.date.month + 1 }}</div>
     </div>
     <div class="next-month" @click="reloadCalendar(1)">></div>
   </div>
@@ -19,13 +19,13 @@
       <tbody class="day-body">
         <tr class="day-row" v-for="index, i in this.$store.state.days" :key="i">
           <td class="day-block" v-for="day in index" :key="day">
-            <div class="day" @click="goWrite(this.$store.state.year, this.$store.state.month, day)">{{ day }}</div>
+            <div class="day" @click="goWrite(this.$store.state.date.year, this.$store.state.date.month, day)">{{ day }}</div>
           </td>
         </tr>
       </tbody>
     </table>
   </div>
-  <div class="write-button" @click="goWrite(this.$store.state.year, this.$store.state.month, this.$store.state.day)">write</div>
+  <div class="write-button" @click="goWrite(this.$store.state.date.year, this.$store.state.date.month, this.$store.state.date.day)">write</div>
 </template>
 
 <script>

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -36,6 +36,7 @@ export default {
     }
   },
   mounted() {
+    this.$store.state.today = new Date();
     this.$store.commit('loadCalendar');
   },
   methods: {

--- a/mj-diary/src/components/CalendarMainPage.vue
+++ b/mj-diary/src/components/CalendarMainPage.vue
@@ -16,16 +16,16 @@
           <th>{{ week }}</th>
         </tr>
       </thead>
-      <tbody class="date-body">
-        <tr class="date-row" v-for="index, i in this.$store.state.days" :key="i">
-          <td class="date-block" v-for="date in index" :key="date">
-            <router-link class="date" to="/write/1">{{ date }}</router-link>
+      <tbody class="day-body">
+        <tr class="day-row" v-for="index, i in this.$store.state.days" :key="i">
+          <td class="day-block" v-for="day in index" :key="day">
+            <div class="day" @click="goWrite(this.$store.state.year, this.$store.state.month, day)">{{ day }}</div>
           </td>
         </tr>
       </tbody>
     </table>
   </div>
-  <router-link class="write-button" to="/write/1">write</router-link>
+  <div class="write-button" @click="goWrite(this.$store.state.year, this.$store.state.month, this.$store.state.day)">write</div>
 </template>
 
 <script>
@@ -37,6 +37,12 @@ export default {
     reloadCalendar(v) {
       this.$store.state.today = new Date(this.$store.state.today.setMonth(this.$store.state.today.getMonth() + v, 1));
       this.$store.commit('loadCalendar');
+    },
+    goWrite(year, month, day) {
+      this.$store.state.wirteMonth = String(month + 1).padStart(2, "0");
+      this.$store.state.writeDay = String(day).padStart(2, "0");
+      this.$store.state.writeDate = String(year) + this.$store.state.wirteMonth + this.$store.state.writeDay;
+      this.$router.push(`/write/${this.$store.state.writeDate}`)
     }
   }
 }
@@ -85,15 +91,15 @@ export default {
   display: flex;
   justify-content: center;
 }
-.date-row {
+.day-row {
   color: black;
   display: flex;
   justify-content: space-around;
 }
-.date-body {
+.day-body {
   width: 100%;
 }
-.date-block {
+.day-block {
   width: 42px;
   height: 50px;
   margin-bottom: 16px;
@@ -101,7 +107,7 @@ export default {
   align-items: flex-start;
   justify-content: center;
 }
-.date {
+.day {
   text-decoration-line: none;
   color: black
 }

--- a/mj-diary/src/components/CalendarWritePage.vue
+++ b/mj-diary/src/components/CalendarWritePage.vue
@@ -3,11 +3,25 @@
     <div class="select-mood">
       <h3>오늘의 기분은?</h3>
       <div class="mood-list">
-        <img src="/mood/happiness.png" />
-        <img src="/mood/angry.png" />
-        <img src="/mood/depressed.png" />
-        <img src="/mood/sad.png" />
-        <img src="/mood/happy.png" />
+        <img 
+        :class="{'colorMood': this.$store.state.todayMood == 'happiness', 'greyMood': this.$store.state.todayMood != 'happiness'}" 
+        @click="this.$store.commit('setMood', 'happiness')"
+        src="/mood/happiness.png" />
+        <img :class="{'colorMood': this.$store.state.todayMood == 'angry', 'greyMood': this.$store.state.todayMood != 'angry'}"
+        @click="this.$store.commit('setMood', 'angry')" 
+        src="/mood/angry.png" />
+        <img 
+        :class="{'colorMood': this.$store.state.todayMood == 'depressed', 'greyMood': this.$store.state.todayMood != 'depressed'}"
+        @click="this.$store.commit('setMood', 'depressed')" 
+        src="/mood/depressed.png" />
+        <img 
+        :class="{'colorMood': this.$store.state.todayMood == 'sad', 'greyMood': this.$store.state.todayMood != 'sad'}"
+        @click="this.$store.commit('setMood', 'sad')" 
+        src="/mood/sad.png" />
+        <img
+        :class="{'colorMood': this.$store.state.todayMood == 'happy', 'greyMood': this.$store.state.todayMood != 'happy'}" 
+        @click="this.$store.commit('setMood', 'happy')" 
+        src="/mood/happy.png" />
       </div>
     </div>
     <div>
@@ -53,8 +67,12 @@ export default {
   display: flex;
   justify-content: space-around;
 }
-img {
-  width: 67px;
+.colorMood {
+  width: 4.25rem;
+}
+.greyMood {
+  width: 4.25rem;
+  filter: grayscale(100%);
 }
 .write-block {
   width: calc(100% - 32px);

--- a/mj-diary/src/components/CalendarWritePage.vue
+++ b/mj-diary/src/components/CalendarWritePage.vue
@@ -27,7 +27,7 @@
     <div>
       <h3>오늘은 무슨 일이 있었나요?</h3>
       <div class="write-block">
-        <div class="today">{{ this.$store.state.year }}년 {{ this.$store.state.wirteMonth }}월 {{ this.$store.state.writeDay }}일</div>
+        <div class="today">{{ this.$store.state.date.year }}년 {{ this.$store.state.wirteMonth }}월 {{ this.$store.state.writeDay }}일</div>
         <textarea class="text-write"></textarea>
       </div>
     </div>

--- a/mj-diary/src/components/CalendarWritePage.vue
+++ b/mj-diary/src/components/CalendarWritePage.vue
@@ -13,23 +13,31 @@
     <div>
       <h3>오늘은 무슨 일이 있었나요?</h3>
       <div class="write-block">
-        <div class="today">2024년 1월 13일</div>
+        <div class="today">{{ this.$store.state.year }}년 {{ this.$store.state.month + 1 }}월 {{ this.$store.state.date }}일</div>
         <textarea class="text-write"></textarea>
       </div>
     </div>
-    <div>
-      <ul class="input-block">
-        <input id="chooseFile" accept="image/*" type="file" class="input-image" />
-        <label for="file" class="input-plus">+</label>
-        <label>Upload Image</label>
-      </ul>
+
+    <div v-if="this.$store.state.imageUrl == ''" class="input-block" @change="uploadImage($event)">
+      <input accept="image/*" type="file" id="input-file" class="input-image" />
+      <label for="input-file" class="input-label">
+        <div>+</div>
+        <div>Upload Image</div>
+      </label>
+    </div>
+    <div v-else class="upload-image" :style="{ backgroundImage: `url(${this.$store.state.imageUrl})` }">
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  
+  methods: {
+    uploadImage(event) {
+      const file = event.target.files;
+      this.$store.commit('setImageUrl', URL.createObjectURL(file[0]));
+    }
+  }
 }
 </script>
 
@@ -50,9 +58,10 @@ img {
 }
 .write-block {
   width: calc(100% - 32px);
-  height: 291px;
+  height: 16.5rem;
   padding: 16px;
   background-color: rgb(255, 255, 152);
+  margin-bottom: 1em;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -69,17 +78,27 @@ img {
   margin-bottom: 16px;
 }
 .input-block {
-  padding: 32px;
   border-style: dotted;
   cursor: pointer;
+}
+.input-image {
+  display: none;
+}
+.input-label {
+  height: 100%;
+  cursor: pointer;
+  padding: 50px;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
-#chooseFile {
-  display: none;
-}
-.input-plus {
-  cursor: pointer;
+.upload-image {
+  width: 100%;
+  height: 150px;
+  overflow: hidden;
+  border: 1px solid black;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 </style>

--- a/mj-diary/src/components/CalendarWritePage.vue
+++ b/mj-diary/src/components/CalendarWritePage.vue
@@ -3,25 +3,11 @@
     <div class="select-mood">
       <h3>오늘의 기분은?</h3>
       <div class="mood-list">
-        <img 
-        :class="{'colorMood': this.$store.state.todayMood == 'happiness', 'greyMood': this.$store.state.todayMood != 'happiness'}" 
-        @click="this.$store.commit('setMood', 'happiness')"
-        src="/mood/happiness.png" />
-        <img :class="{'colorMood': this.$store.state.todayMood == 'angry', 'greyMood': this.$store.state.todayMood != 'angry'}"
-        @click="this.$store.commit('setMood', 'angry')" 
-        src="/mood/angry.png" />
-        <img 
-        :class="{'colorMood': this.$store.state.todayMood == 'depressed', 'greyMood': this.$store.state.todayMood != 'depressed'}"
-        @click="this.$store.commit('setMood', 'depressed')" 
-        src="/mood/depressed.png" />
-        <img 
-        :class="{'colorMood': this.$store.state.todayMood == 'sad', 'greyMood': this.$store.state.todayMood != 'sad'}"
-        @click="this.$store.commit('setMood', 'sad')" 
-        src="/mood/sad.png" />
-        <img
-        :class="{'colorMood': this.$store.state.todayMood == 'happy', 'greyMood': this.$store.state.todayMood != 'happy'}" 
-        @click="this.$store.commit('setMood', 'happy')" 
-        src="/mood/happy.png" />
+        <img :class="setImageMood('happiness')" @click="this.$store.commit('setMood', 'happiness')" src="/mood/happiness.png" />
+        <img :class="setImageMood('angry')" @click="this.$store.commit('setMood', 'angry')" src="/mood/angry.png" />
+        <img :class="setImageMood('depressed')" @click="this.$store.commit('setMood', 'depressed')" src="/mood/depressed.png" />
+        <img :class="setImageMood('sad')" @click="this.$store.commit('setMood', 'sad')" src="/mood/sad.png" />
+        <img :class="setImageMood('happy')" @click="this.$store.commit('setMood', 'happy')" src="/mood/happy.png" />
       </div>
     </div>
     <div>
@@ -50,6 +36,9 @@ export default {
     uploadImage(event) {
       const file = event.target.files;
       this.$store.commit('setImageUrl', URL.createObjectURL(file[0]));
+    },
+    setImageMood(mood) {
+      return this.$store.state.todayMood == mood ? 'colorMood' : 'greyMood'
     }
   }
 }

--- a/mj-diary/src/components/CalendarWritePage.vue
+++ b/mj-diary/src/components/CalendarWritePage.vue
@@ -13,7 +13,7 @@
     <div>
       <h3>오늘은 무슨 일이 있었나요?</h3>
       <div class="write-block">
-        <div class="today">{{ this.$store.state.year }}년 {{ this.$store.state.month + 1 }}월 {{ this.$store.state.date }}일</div>
+        <div class="today">{{ this.$store.state.year }}년 {{ this.$store.state.wirteMonth }}월 {{ this.$store.state.writeDay }}일</div>
         <textarea class="text-write"></textarea>
       </div>
     </div>

--- a/mj-diary/src/router.js
+++ b/mj-diary/src/router.js
@@ -8,7 +8,7 @@ const routes = [
     path: "/main",
     component: () => import("./components/CalendarMainPage.vue")
   }, {
-    path: "/write/:date",
+    path: "/write/:writeDate",
     component: () => import("./components/CalendarWritePage.vue")
   }, {
     path: "/statistics",

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -3,10 +3,44 @@ import { createStore } from 'vuex';
 const store = createStore({
   state() {
     return {
-      prev: "<"
+      prev: "<",
+      weeks: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'],
+      year: 0,
+      month: 0,
+      date: 0,
+      today: new Date(),
+      days: [],
+      startDay: 0,
+      endDay: 0,
+      basicDays: 0,
+      emptyDays: 0,
+      combinedDays: 0
     }
   },
   mutations: {
+    loadCalendar(state) {
+      state.days = [];
+      state.year = state.today.getFullYear();
+      state.month = state.today.getMonth();
+      state.date = state.today.getDate();
+      state.startDay = new Date(state.year, state.month, 1).getDay();
+      state.endDay = new Date(state.year, state.month + 1, 0).getDate();
+      state.basicDays = Array.from({ length: state.endDay }, (v, i) => i + 1);
+      state.emptyDays = Array(state.startDay).fill(null);
+      state.combinedDays = [...state.emptyDays, ...state.basicDays];
+
+      for(let i = 0; i < 35; i++) {
+        if(state.combinedDays[i] != null) {
+          continue;
+        }else {
+          state.combinedDays.push(null);
+        }
+      }
+
+      for(let i = 0; i < state.endDay + state.startDay; i += 7) {
+        state.days.push(state.combinedDays.slice(i, i+7));
+      }
+    }
   }
 })
 

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -7,7 +7,7 @@ const store = createStore({
       weeks: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'],
       year: 0,
       month: 0,
-      date: 0,
+      day: 0,
       today: new Date(),
       days: [],
       startDay: 0,
@@ -15,7 +15,10 @@ const store = createStore({
       basicDays: 0,
       emptyDays: 0,
       combinedDays: 0,
-      imageUrl: ''
+      imageUrl: '',
+      wirteMonth: '',
+      writeDay: '',
+      writeDate: ''
     }
   },
   mutations: {
@@ -23,7 +26,7 @@ const store = createStore({
       state.days = [];
       state.year = state.today.getFullYear();
       state.month = state.today.getMonth();
-      state.date = state.today.getDate();
+      state.day = state.today.getDate();
       state.startDay = new Date(state.year, state.month, 1).getDay();
       state.endDay = new Date(state.year, state.month + 1, 0).getDate();
       state.basicDays = Array.from({ length: state.endDay }, (v, i) => i + 1);

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -3,7 +3,6 @@ import { createStore } from 'vuex';
 const store = createStore({
   state() {
     return {
-      prev: "<",
       weeks: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'],
       year: 0,
       month: 0,

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -21,6 +21,7 @@ const store = createStore({
       writeDay: '',
       writeDate: '',
       todayMood: '',
+      moodState: [false, false, false, false, false],
       showNavButton: false
     }
   },

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -21,6 +21,7 @@ const store = createStore({
       writeDay: '',
       writeDate: '',
       todayMood: '',
+      showNavButton: false
     }
   },
   mutations: {
@@ -52,10 +53,16 @@ const store = createStore({
     },
     setMood(state, mood) {
       state.todayMood = mood;
-    }, 
-    submitDiary(state) {
-      state.todayMood = '';
-      state.imageUrl = '';
+    },
+    setShowButton(state) {
+      state.showNavButton = !state.showNavButton;
+    }
+  },
+  actions: {
+    submitDiary(context) {
+      context.state.todayMood = '';
+      context.state.imageUrl = '';
+      context.commit('setShowButton');
     }
   }
 })

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -18,7 +18,8 @@ const store = createStore({
       imageUrl: '',
       wirteMonth: '',
       writeDay: '',
-      writeDate: ''
+      writeDate: '',
+      todayMood: '',
     }
   },
   mutations: {
@@ -47,6 +48,9 @@ const store = createStore({
     },
     setImageUrl(state, url) {
       state.imageUrl = url;
+    },
+    setMood(state, mood) {
+      state.todayMood = mood;
     }
   }
 })

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -51,6 +51,10 @@ const store = createStore({
     },
     setMood(state, mood) {
       state.todayMood = mood;
+    },
+    submitDiary(state) {
+      state.todayMood = '';
+      state.imageUrl = '';
     }
   }
 })

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -25,7 +25,6 @@ const store = createStore({
   },
   mutations: {
     loadCalendar(state) {
-      state.today = new Date();
       state.days = [];
       state.date.year = state.today.getFullYear();
       state.date.month = state.today.getMonth();

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -14,7 +14,8 @@ const store = createStore({
       endDay: 0,
       basicDays: 0,
       emptyDays: 0,
-      combinedDays: 0
+      combinedDays: 0,
+      imageUrl: ''
     }
   },
   mutations: {
@@ -38,8 +39,11 @@ const store = createStore({
       }
 
       for(let i = 0; i < state.endDay + state.startDay; i += 7) {
-        state.days.push(state.combinedDays.slice(i, i+7));
+        state.days.push(state.combinedDays.slice(i, i + 7));
       }
+    },
+    setImageUrl(state, url) {
+      state.imageUrl = url;
     }
   }
 })

--- a/mj-diary/src/store.js
+++ b/mj-diary/src/store.js
@@ -4,10 +4,12 @@ const store = createStore({
   state() {
     return {
       weeks: ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'],
-      year: 0,
-      month: 0,
-      day: 0,
-      today: new Date(),
+      date: {
+        year: 0,
+        month: 0,
+        day: 0,
+      },
+      today: '',
       days: [],
       startDay: 0,
       endDay: 0,
@@ -23,12 +25,13 @@ const store = createStore({
   },
   mutations: {
     loadCalendar(state) {
+      state.today = new Date();
       state.days = [];
-      state.year = state.today.getFullYear();
-      state.month = state.today.getMonth();
-      state.day = state.today.getDate();
-      state.startDay = new Date(state.year, state.month, 1).getDay();
-      state.endDay = new Date(state.year, state.month + 1, 0).getDate();
+      state.date.year = state.today.getFullYear();
+      state.date.month = state.today.getMonth();
+      state.date.day = state.today.getDate();
+      state.startDay = new Date(state.date.year, state.date.month, 1).getDay();
+      state.endDay = new Date(state.date.year, state.date.month + 1, 0).getDate();
       state.basicDays = Array.from({ length: state.endDay }, (v, i) => i + 1);
       state.emptyDays = Array(state.startDay).fill(null);
       state.combinedDays = [...state.emptyDays, ...state.basicDays];
@@ -50,7 +53,7 @@ const store = createStore({
     },
     setMood(state, mood) {
       state.todayMood = mood;
-    },
+    }, 
     submitDiary(state) {
       state.todayMood = '';
       state.imageUrl = '';


### PR DESCRIPTION
## Docs

- [figma design templete](https://www.figma.com/file/0ByGSnJpm6DdAwqOrPSSeR/Mango-Diary?type=design&node-id=42-7&mode=design&t=kfGm1MJs0TyVDcIj-0)

## Changes

- before : 캘린더 UI만 구현, 이미지 업로드 칸만 생성, 일기 작성 router가 한 경로, 일기 작성페이지 이모지만 띄움
- after : 이번 달 기준으로 캘린더 구현, 이미지 업로드 가능, 일기 작성 날짜별로 router 이동, 이모지 선택 가능
- images
![splash](https://github.com/DEV-TINO/Mango-Diary-MJ/assets/59122931/a19c81b8-34b7-4f7c-9a38-6b41d9680163)
![main](https://github.com/DEV-TINO/Mango-Diary-MJ/assets/59122931/3981bdd5-8457-49a2-b210-00cef684db09)
![write](https://github.com/DEV-TINO/Mango-Diary-MJ/assets/59122931/bcf691ba-10d9-494f-9489-d94c87e711d9)
![statistics](https://github.com/DEV-TINO/Mango-Diary-MJ/assets/59122931/cd2a7025-fff6-489a-b62c-1bc4014e68f9)

## Review Points
- 캘린더 달에 맞춰서 제대로 뜨는지
- 이미지 잘 업로드 되는지
- 일기 작성 router
- 이모지 선택

#### Problem
일기 작성 페이지 router 링크를 어떻게 고유하게 할 수 있을지

#### Solution
날짜의 고유성을 이용하여 router 구현

## Test Checklist

- [x] check 1: 캘린더 구현
- [x] check 2: 이미지 업로드
- [x] check 3: 일기 작성 페이지 router
- [x] check 4: 이모지 선택
